### PR TITLE
[#17] Integrate MailHog

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -173,6 +173,13 @@ Vagrant.configure("2") do |config|
        env: configure["mysql"]
   end
 
+  # MailHog
+  if configure["provision"]["mailhog"]
+      config.vm.provision "mailhog",
+       type: "shell",
+       path: "provisioning/mailhog.sh"
+  end
+
   # Memcached
   if configure["provision"]["memcached"]
       config.vm.provision "memcached",
@@ -224,7 +231,7 @@ Vagrant.configure("2") do |config|
     end
   end
 
-  # Packes post install
+  # Packages post install
   if !packages["postprovision"].nil? && !packages["postprovision"].empty?
     packages = packages["postprovision"].join(" ");
     config.vm.provision "postprovision",

--- a/configure/box.sample.yml
+++ b/configure/box.sample.yml
@@ -66,6 +66,7 @@ provision:
   apache: false
   nvm: false
   mysql: false
+  mailhog: false
   memcached: false
   redis: false
   docker: false

--- a/provisioning/mailhog.sh
+++ b/provisioning/mailhog.sh
@@ -23,7 +23,7 @@ WantedBy=multi-user.target
 EOT
 
 # Add MailHog to autorun
-update-rc.d mailhog defaults
+systemctl enable mailhog.service
 
 # Start MailHog service
 service mailhog start

--- a/provisioning/mailhog.sh
+++ b/provisioning/mailhog.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+echo "Installing MailHog..."
+
+apt-get install -y \
+golang-go
+
+GOPATH=/opt/go \
+go get github.com/mailhog/MailHog
+
+ln -s /opt/go/bin/MailHog /usr/local/bin/MailHog
+
+# Create MailHog service file
+cat <<EOT > /etc/systemd/system/mailhog.service
+[Unit]
+Description=MailHog service
+
+[Service]
+ExecStart=/usr/local/bin/MailHog
+
+[Install]
+WantedBy=multi-user.target
+EOT
+
+# Add MailHog to autorun
+update-rc.d mailhog defaults
+
+# Start MailHog service
+service mailhog start
+
+# Install postfix as deliverer
+DEBIAN_FRONTEND=noninteractive \
+apt-get install -y \
+postfix
+
+# Configure postfix
+postconf -e "relayhost = 127.0.0.1:1025"
+postconf -e "inet_interfaces = loopback-only"
+postconf -e "default_transport = smtp"
+postconf -e "relay_transport = error"
+
+# Reload service
+service postfix reload
+
+exit $?


### PR DESCRIPTION
This pull-request integrates MailHog and postfix as delivery service.
The advantage of this method is that every email (regardless of the PHP configuration) is recorded in MailHog.

If MailHog is active, you can reach it via [IP-address]:8025.

- Add MailHog package
- Add postfix as deliverer
- Configure postfix
- Add MailHog flags to box.sample.yml and Vagrantfile